### PR TITLE
add compatibility for python 3.10 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 siman.egg-info/
 siman/libfindpores.so
 siman_10_09_2021
+build

--- a/siman/small_functions.py
+++ b/siman/small_functions.py
@@ -2,7 +2,6 @@
 from __future__ import division, unicode_literals, absolute_import 
 import os, math, re, sys
 import numpy as np
-from collections import Iterable
 import shutil, gzip
 import traceback
 from contextlib import contextmanager
@@ -15,6 +14,11 @@ except:
         string_types = basestring #for python 2.7
     except NameError:
         string_types = str # for python 3
+        
+try:
+    from collections.abc import Iterable # for python >=3.10
+except ImportError:
+    from collections import Iterable # for python < 3.10
 
 from siman import header
 from siman.header import printlog


### PR DESCRIPTION
This pull request addresses compatibility issues by importing the Iterable class from the appropriate location based on the Python version in use. Specifically:

For Python 3.10 and later, it imports Iterable from collections.abc.
For Python versions earlier than 3.10, it imports Iterable from collections.